### PR TITLE
"seer starknet generate" now generates event crawler and parser

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var SeerVersion string = "0.0.4"
+var SeerVersion string = "0.0.5"


### PR DESCRIPTION
This PR adds an event crawler and event parser (for crawled events) to the code generated by `seer starknet generate`.

Resolves https://github.com/moonstream-to/seer/issues/2