### PR TITLE
Added "--hardhat" argument to "seer evm generate"

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var SeerVersion string = "0.1.2"
+var SeerVersion string = "0.1.3"


### PR DESCRIPTION
This allows users to codegen Go bindings and CLIs from Hardhat build artifacts.