### PR TITLE
Fixed how the generated CLIs handle byte array inputs

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var SeerVersion string = "0.1.14"
+var SeerVersion string = "0.1.15"


### PR DESCRIPTION
Nested byte arrays were previously being handled horribly erroneously by `seer evm generate` as far as generating CLIs was concerned.

This PR aims to fix this issue.

Partially resolves https://github.com/moonstream-to/seer/issues/8