### PR TITLE
Reinvent crawler with pack struct

### DIFF
--- a/blockchain/arbitrum_one/arbitrum_one.go
+++ b/blockchain/arbitrum_one/arbitrum_one.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/arbitrum_sepolia/arbitrum_sepolia.go
+++ b/blockchain/arbitrum_sepolia/arbitrum_sepolia.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/blockchain.go.tmpl
+++ b/blockchain/blockchain.go.tmpl
@@ -215,7 +215,7 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	}
 
 	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/ethereum/ethereum.go
+++ b/blockchain/ethereum/ethereum.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/game7_orbit_arbitrum_sepolia/game7_orbit_arbitrum_sepolia.go
+++ b/blockchain/game7_orbit_arbitrum_sepolia/game7_orbit_arbitrum_sepolia.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/game7_testnet/game7_testnet.go
+++ b/blockchain/game7_testnet/game7_testnet.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/imx_zkevm/imx_zkevm.go
+++ b/blockchain/imx_zkevm/imx_zkevm.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/imx_zkevm_sepolia/imx_zkevm_sepolia.go
+++ b/blockchain/imx_zkevm_sepolia/imx_zkevm_sepolia.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/mantle/mantle.go
+++ b/blockchain/mantle/mantle.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/mantle_sepolia/mantle_sepolia.go
+++ b/blockchain/mantle_sepolia/mantle_sepolia.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/polygon/polygon.go
+++ b/blockchain/polygon/polygon.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/sepolia/sepolia.go
+++ b/blockchain/sepolia/sepolia.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/xai/xai.go
+++ b/blockchain/xai/xai.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/blockchain/xai_sepolia/xai_sepolia.go
+++ b/blockchain/xai_sepolia/xai_sepolia.go
@@ -214,8 +214,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 		blockNumbersRange = append(blockNumbersRange, new(big.Int).Set(i))
 	}
 
-	sem := make(chan struct{}, maxRequests)             // Semaphore to control concurrency
-	errChan := make(chan error, len(blockNumbersRange)) // Handle errors to stop corrupted processing
+	sem := make(chan struct{}, maxRequests) // Semaphore to control concurrency
+	errChan := make(chan error, 1)
 
 	for _, b := range blockNumbersRange {
 		wg.Add(1)
@@ -247,10 +247,8 @@ func (c *Client) FetchBlocksInRangeAsync(from, to *big.Int, debug bool, maxReque
 	close(sem)
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return nil, err
-		}
+	if err := <-errChan; err != nil {
+		return nil, err
 	}
 
 	return blocks, nil

--- a/cmd.go
+++ b/cmd.go
@@ -218,11 +218,10 @@ func CreateStarknetCommand() *cobra.Command {
 }
 
 func CreateCrawlerCommand() *cobra.Command {
-	var startBlock, endBlock, confirmations int64
+	var startBlock, finalBlock, confirmations, batchSize int64
 	var timeout, threads, protoTimeLimit int
 	var protoSizeLimit uint64
 	var chain, baseDir string
-	var force bool
 
 	crawlerCmd := &cobra.Command{
 		Use:   "crawler",
@@ -249,7 +248,7 @@ func CreateCrawlerCommand() *cobra.Command {
 
 			indexer.InitDBConnection()
 
-			newCrawler, crawlerError := crawler.NewCrawler(chain, startBlock, endBlock, confirmations, timeout, baseDir, force, protoSizeLimit, protoTimeLimit)
+			newCrawler, crawlerError := crawler.NewCrawler(chain, startBlock, finalBlock, confirmations, batchSize, timeout, baseDir, protoSizeLimit, protoTimeLimit)
 			if crawlerError != nil {
 				return crawlerError
 			}
@@ -273,12 +272,12 @@ func CreateCrawlerCommand() *cobra.Command {
 
 	crawlerCmd.Flags().StringVar(&chain, "chain", "ethereum", "The blockchain to crawl (default: ethereum)")
 	crawlerCmd.Flags().Int64Var(&startBlock, "start-block", 0, "The block number to start crawling from (default: fetch from database, if it is empty, run from latestBlockNumber minus shift)")
-	crawlerCmd.Flags().Int64Var(&endBlock, "end-block", 0, "The block number to end crawling at (default: endless)")
+	crawlerCmd.Flags().Int64Var(&finalBlock, "final-block", 0, "The block number to end crawling at (default: endless)")
 	crawlerCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout for the crawler in seconds (default: 30)")
 	crawlerCmd.Flags().IntVar(&threads, "threads", 1, "Number of go-routines for concurrent crawling (default: 1)")
+	crawlerCmd.Flags().Int64Var(&batchSize, "batch-size", 10, "The number of blocks to crawl in each batch (default: 10)")
 	crawlerCmd.Flags().Int64Var(&confirmations, "confirmations", 10, "The number of confirmations to consider for block finality (default: 10)")
 	crawlerCmd.Flags().StringVar(&baseDir, "base-dir", "", "The base directory to store the crawled data (default: '')")
-	crawlerCmd.Flags().BoolVar(&force, "force", false, "Set this flag to force the crawler start from the specified block, otherwise it checks database latest indexed block number (default: false)")
 	crawlerCmd.Flags().Uint64Var(&protoSizeLimit, "proto-size-limit", 25, "Proto file size limit in Mb (default: 25Mb)")
 	crawlerCmd.Flags().IntVar(&protoTimeLimit, "proto-time-limit", 300, "Proto time limit in seconds (default: 300sec)")
 

--- a/cmd.go
+++ b/cmd.go
@@ -218,7 +218,7 @@ func CreateStarknetCommand() *cobra.Command {
 }
 
 func CreateCrawlerCommand() *cobra.Command {
-	var startBlock, finalBlock, confirmations, batchSize int64
+	var startBlock, finalBlock, confirmations uint64
 	var timeout, threads, protoTimeLimit int
 	var protoSizeLimit uint64
 	var chain, baseDir string
@@ -248,7 +248,7 @@ func CreateCrawlerCommand() *cobra.Command {
 
 			indexer.InitDBConnection()
 
-			newCrawler, crawlerError := crawler.NewCrawler(chain, startBlock, finalBlock, confirmations, batchSize, timeout, baseDir, protoSizeLimit, protoTimeLimit)
+			newCrawler, crawlerError := crawler.NewCrawler(chain, startBlock, finalBlock, confirmations, timeout, baseDir, protoSizeLimit, protoTimeLimit)
 			if crawlerError != nil {
 				return crawlerError
 			}
@@ -258,7 +258,7 @@ func CreateCrawlerCommand() *cobra.Command {
 				return fmt.Errorf("Failed to get latest block number: %v", latestErr)
 			}
 
-			if startBlock > latestBlockNumber.Int64() {
+			if startBlock > latestBlockNumber.Uint64() {
 				log.Fatalf("Start block could not be greater then latest block number at blockchain")
 			}
 
@@ -271,12 +271,11 @@ func CreateCrawlerCommand() *cobra.Command {
 	}
 
 	crawlerCmd.Flags().StringVar(&chain, "chain", "ethereum", "The blockchain to crawl (default: ethereum)")
-	crawlerCmd.Flags().Int64Var(&startBlock, "start-block", 0, "The block number to start crawling from (default: fetch from database, if it is empty, run from latestBlockNumber minus shift)")
-	crawlerCmd.Flags().Int64Var(&finalBlock, "final-block", 0, "The block number to end crawling at (default: endless)")
+	crawlerCmd.Flags().Uint64Var(&startBlock, "start-block", 0, "The block number to start crawling from (default: fetch from database, if it is empty, run from latestBlockNumber minus shift)")
+	crawlerCmd.Flags().Uint64Var(&finalBlock, "final-block", 0, "The block number to end crawling at (default: endless)")
 	crawlerCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout for the crawler in seconds (default: 30)")
 	crawlerCmd.Flags().IntVar(&threads, "threads", 1, "Number of go-routines for concurrent crawling (default: 1)")
-	crawlerCmd.Flags().Int64Var(&batchSize, "batch-size", 10, "The number of blocks to crawl in each batch (default: 10)")
-	crawlerCmd.Flags().Int64Var(&confirmations, "confirmations", 10, "The number of confirmations to consider for block finality (default: 10)")
+	crawlerCmd.Flags().Uint64Var(&confirmations, "confirmations", 10, "The number of confirmations to consider for block finality (default: 10)")
 	crawlerCmd.Flags().StringVar(&baseDir, "base-dir", "", "The base directory to store the crawled data (default: '')")
 	crawlerCmd.Flags().Uint64Var(&protoSizeLimit, "proto-size-limit", 25, "Proto file size limit in Mb (default: 25Mb)")
 	crawlerCmd.Flags().IntVar(&protoTimeLimit, "proto-time-limit", 300, "Proto time limit in seconds (default: 300sec)")

--- a/cmd.go
+++ b/cmd.go
@@ -218,7 +218,7 @@ func CreateStarknetCommand() *cobra.Command {
 }
 
 func CreateCrawlerCommand() *cobra.Command {
-	var startBlock, finalBlock, confirmations uint64
+	var startBlock, finalBlock, confirmations, batchSize int64
 	var timeout, threads, protoTimeLimit int
 	var protoSizeLimit uint64
 	var chain, baseDir string
@@ -248,7 +248,7 @@ func CreateCrawlerCommand() *cobra.Command {
 
 			indexer.InitDBConnection()
 
-			newCrawler, crawlerError := crawler.NewCrawler(chain, startBlock, finalBlock, confirmations, timeout, baseDir, protoSizeLimit, protoTimeLimit)
+			newCrawler, crawlerError := crawler.NewCrawler(chain, startBlock, finalBlock, confirmations, batchSize, timeout, baseDir, protoSizeLimit, protoTimeLimit)
 			if crawlerError != nil {
 				return crawlerError
 			}
@@ -258,11 +258,11 @@ func CreateCrawlerCommand() *cobra.Command {
 				return fmt.Errorf("Failed to get latest block number: %v", latestErr)
 			}
 
-			if startBlock > latestBlockNumber.Uint64() {
+			if startBlock > latestBlockNumber.Int64() {
 				log.Fatalf("Start block could not be greater then latest block number at blockchain")
 			}
 
-			crawler.CurrentBlockchainState.SetLatestBlockNumber(latestBlockNumber)
+			crawler.CurrentBlockchainState.RaiseLatestBlockNumber(latestBlockNumber)
 
 			newCrawler.Start(threads)
 
@@ -271,11 +271,12 @@ func CreateCrawlerCommand() *cobra.Command {
 	}
 
 	crawlerCmd.Flags().StringVar(&chain, "chain", "ethereum", "The blockchain to crawl (default: ethereum)")
-	crawlerCmd.Flags().Uint64Var(&startBlock, "start-block", 0, "The block number to start crawling from (default: fetch from database, if it is empty, run from latestBlockNumber minus shift)")
-	crawlerCmd.Flags().Uint64Var(&finalBlock, "final-block", 0, "The block number to end crawling at (default: endless)")
+	crawlerCmd.Flags().Int64Var(&startBlock, "start-block", 0, "The block number to start crawling from (default: fetch from database, if it is empty, run from latestBlockNumber minus shift)")
+	crawlerCmd.Flags().Int64Var(&finalBlock, "final-block", 0, "The block number to end crawling at (default: endless)")
 	crawlerCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout for the crawler in seconds (default: 30)")
 	crawlerCmd.Flags().IntVar(&threads, "threads", 1, "Number of go-routines for concurrent crawling (default: 1)")
-	crawlerCmd.Flags().Uint64Var(&confirmations, "confirmations", 10, "The number of confirmations to consider for block finality (default: 10)")
+	crawlerCmd.Flags().Int64Var(&confirmations, "confirmations", 10, "The number of confirmations to consider for block finality (default: 10)")
+	crawlerCmd.Flags().Int64Var(&batchSize, "batch-size", 10, "Dynamically changed maximum number of blocks to crawl in each batch (default: 10)")
 	crawlerCmd.Flags().StringVar(&baseDir, "base-dir", "", "The base directory to store the crawled data (default: '')")
 	crawlerCmd.Flags().Uint64Var(&protoSizeLimit, "proto-size-limit", 25, "Proto file size limit in Mb (default: 25Mb)")
 	crawlerCmd.Flags().IntVar(&protoTimeLimit, "proto-time-limit", 300, "Proto time limit in seconds (default: 300sec)")
@@ -335,7 +336,7 @@ func CreateSynchronizerCommand() *cobra.Command {
 				log.Fatalf("Start block could not be greater then latest block number at blockchain")
 			}
 
-			crawler.CurrentBlockchainState.SetLatestBlockNumber(latestBlockNumber)
+			crawler.CurrentBlockchainState.RaiseLatestBlockNumber(latestBlockNumber)
 
 			newSynchronizer.Start(customerDbUriFlag)
 

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -248,7 +248,7 @@ func (c *Crawler) Start(threads int) {
 	retryAttempts := 3
 	retryWaitTime := 5 * time.Second
 	waitForBlocksTime := retryWaitTime
-	maxWaitForBlocksTime := 1 * retryWaitTime
+	maxWaitForBlocksTime := 24 * retryWaitTime
 
 	// If Start block is not set, using last crawled block from indexes database
 	if c.startBlock == 0 {

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -255,6 +255,7 @@ func (c *Crawler) Start(threads int) {
 		log.Printf("Start block fetched from indexes database and set to: %d\n", c.startBlock)
 	}
 
+	var isFinal bool
 	var endBlock int64
 	var crawlPack CrawlPack
 
@@ -265,9 +266,10 @@ func (c *Crawler) Start(threads int) {
 			log.Printf("[DEBUG] [crawler.Start.1] latestBlock: %d, c.endBlock: %d, c.startBlock: %d, dynamicBatchSize: %d, PackStartBlock: %d", CurrentBlockchainState.GetLatestBlockNumber().Uint64(), endBlock, c.startBlock, dynamicBatch.GetSize(), crawlPack.PackStartBlock)
 		}
 
-		// Check if final block specified at start reached then stop
+		// Check if final block specified at trigger stop
 		if c.finalBlock != 0 && endBlock >= c.finalBlock {
-			break
+			endBlock = c.finalBlock
+			isFinal = true
 		}
 
 		// Push pack to database and storage if time comes
@@ -350,6 +352,10 @@ func (c *Crawler) Start(threads int) {
 			return nil
 		}); retryErr != nil {
 			log.Fatalf("Crawl retry operation failed: %v", retryErr)
+		}
+
+		if isFinal {
+			break
 		}
 
 		c.startBlock = endBlock + 1

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -173,7 +173,7 @@ func (cp *CrawlPack) ProcessAndPush(client seer_blockchain.BlockchainClient, cra
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	errChan := make(chan error, 2)
+	errChan := make(chan error, 1)
 
 	go func() {
 		defer wg.Done()
@@ -229,10 +229,8 @@ func (cp *CrawlPack) ProcessAndPush(client seer_blockchain.BlockchainClient, cra
 	wg.Wait()
 	close(errChan)
 
-	for err := range errChan {
-		if err != nil {
-			return fmt.Errorf("error during processing writes, err: %v", err)
-		}
+	if err := <-errChan; err != nil {
+		return err
 	}
 
 	return nil
@@ -250,7 +248,7 @@ func (c *Crawler) Start(threads int) {
 	retryAttempts := 3
 	retryWaitTime := 5 * time.Second
 	waitForBlocksTime := retryWaitTime
-	maxWaitForBlocksTime := 24 * retryWaitTime
+	maxWaitForBlocksTime := 1 * retryWaitTime
 
 	// If Start block is not set, using last crawled block from indexes database
 	if c.startBlock == 0 {

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -250,10 +250,7 @@ func (c *Crawler) Start(threads int) {
 	retryAttempts := 3
 	retryWaitTime := 5 * time.Second
 	waitForBlocksTime := retryWaitTime
-
-	/////// TODO!!
-	///// TODO
-	maxWaitForBlocksTime := 1 * retryWaitTime
+	maxWaitForBlocksTime := 24 * retryWaitTime
 
 	// If Start block is not set, using last crawled block from indexes database
 	if c.startBlock == 0 {

--- a/crawler/settings.go
+++ b/crawler/settings.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	SeerDefaultBlockShift    int64  = 100
 	SeerCrawlerStoragePrefix string = "dev"
 
 	BlockchainURLs map[string]string

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -272,7 +272,7 @@ func (d *Synchronizer) SyncCycle(customerDbUriFlag string) (bool, error) {
 			if latestErr != nil {
 				return isEnd, fmt.Errorf("failed to get latest block number: %v", latestErr)
 			}
-			d.startBlock = uint64(crawler.SetDefaultStartBlock(0, latestBlockNumber))
+			d.startBlock = uint64(latestBlockNumber.Int64() - crawler.SeerDefaultBlockShift)
 		}
 	}
 


### PR DESCRIPTION
Changes:

- Fixed bug when it does not crawl and push last range of blocks because batch size not allow it
- Fixed bug with incorrect path value saving to database happening when waiting for new blocks and rewrites incorrect end block
- Implemented new feature with unlimited batches (limited only by brandwidth with node ~40 blocks max), now batch flag sets maximum batch size and reducec dynamicly